### PR TITLE
DDF-383 Fix test that fails in some timezones (UTC+7 or more).

### DIFF
--- a/csw/spatial-csw-converter/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/impl/TestCswRecordConverter.java
+++ b/csw/spatial-csw-converter/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/impl/TestCswRecordConverter.java
@@ -359,7 +359,7 @@ public class TestCswRecordConverter {
         assertThat(ser, not(nullValue()));
         assertThat(Date.class.isAssignableFrom(ser.getClass()), is(true));
         Date date = (Date) ser;
-        Calendar cal = Calendar.getInstance();
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
         cal.setTime(date);
         assertThat(cal.get(Calendar.MONTH), equalTo(Calendar.MAY));
         assertThat(cal.get(Calendar.YEAR), equalTo(2013));


### PR DESCRIPTION
getInstance() with no arguments uses local timezone, so the check for day of
month will return 4 (instead of the expected 3) for some timezones.

If we getInstance with UTC timezone, it'll work reliably.
