### PR TITLE
DDF-910 Changing password fields to actually be password fields

### DIFF
--- a/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -25,7 +25,7 @@
         <AD description="Username for CSW Service (optional)" name="Username" id="username"
             required="false" type="String" />
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
-            required="false" type="String" />
+            required="false" type="Password" />
             
         <AD description="Disable CN check for the server certificate. This should only be used when testing." name="Disable CN Check" id="disableCnCheck" required="true"
             type="Boolean" default="false" />

--- a/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -28,7 +28,7 @@
         <AD description="Username for WFS Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for WFS Service (optional)" name="Password" id="password"
-            required="false" type="String"/>
+            required="false" type="Password"/>
         <AD name="Non Queryable Properties" id="nonQueryableProperties" required="false" type="String"
             cardinality="100"
             description="Properties listed here will NOT be queryable and any attempt to filter on these properties
@@ -77,7 +77,7 @@
         <AD description="Username for WFS Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for WFS Service (optional)" name="Password" id="password"
-            required="false" type="String"/>
+            required="false" type="Password"/>
         <AD name="Non Queryable Properties" id="nonQueryableProperties" required="false" type="String"
             cardinality="100"
             description="Properties listed here will NOT be queryable and any attempt to filter on these properties

--- a/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -41,7 +41,7 @@
         <AD description="Username for tge WFS Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for the WFS Service (optional)" name="Password" id="password"
-            required="false" type="String"/>
+            required="false" type="Password"/>
         <AD name="Non Queryable Properties" id="nonQueryableProperties" required="false"
             type="String"
             cardinality="100"
@@ -102,7 +102,7 @@
         <AD description="Username for the WFS Service (optional)" name="Username" id="username"
             required="false" type="String"/>
         <AD description="Password for the WFS Service (optional)" name="Password" id="password"
-            required="false" type="String"/>
+            required="false" type="Password"/>
         <AD name="Non Queryable Properties" id="nonQueryableProperties" required="false"
             type="String"
             cardinality="100"


### PR DESCRIPTION
The password fields for the WFS v#.0.0 configs were using regular text fields for the passwords. Changed them over to actual password fields.
