### PR TITLE
Ddf 970

### DIFF
--- a/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsSource.java
+++ b/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsSource.java
@@ -227,7 +227,7 @@ public class WfsSource extends MaskableImpl implements FederatedSource, Connecte
      * 
      */
     public void init() {
-              setupAvailabilityPoll();
+        setupAvailabilityPoll();
     }
 
     public void destroy() {

--- a/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsSource.java
+++ b/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsSource.java
@@ -338,6 +338,10 @@ public class WfsSource extends MaskableImpl implements FederatedSource, Connecte
             } else {
                 availabilityTask.setInterval(interval);
             }
+            // Run the availability check immediately prior to scheduling it in a thread.
+            // This is necessary to allow the catalog framework to have the correct
+            // availability when the source is bound
+            availabilityTask.run();
             // Run the availability check every 1 second. The actually call to
             // the remote server will only occur if the pollInterval has
             // elapsed.

--- a/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsSource.java
+++ b/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsSource.java
@@ -227,7 +227,7 @@ public class WfsSource extends MaskableImpl implements FederatedSource, Connecte
      * 
      */
     public void init() {
-        setupAvailabilityPoll();
+              setupAvailabilityPoll();
     }
 
     public void destroy() {

--- a/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/TestWfsSource.java
+++ b/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/TestWfsSource.java
@@ -273,6 +273,13 @@ public class TestWfsSource {
 
         source = new WfsSource(mockWfs, new GeotoolsFilterAdapterImpl(), mockContext,
                 mockAvailabilityTask);
+
+    }
+
+    @Test
+    public void testAvailability() throws WfsException {
+        setUp(NO_PROPERTY_SCHEMA, null, null, ONE_FEATURE, null);
+        assertTrue(source.isAvailable());
     }
 
     @Test(expected = UnsupportedQueryException.class)

--- a/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
+++ b/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
@@ -326,6 +326,10 @@ public class WfsSource extends MaskableImpl implements FederatedSource, Connecte
             } else {
                 availabilityTask.setInterval(interval);
             }
+            // Run the availability check immediately prior to scheduling it in a thread.
+            // This is necessary to allow the catalog framework to have the correct
+            // availability when the source is bound
+            availabilityTask.run();
             // Run the availability check every 1 second. The actually call to
             // the remote server will only occur if the pollInterval has
             // elapsed.

--- a/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/TestWfsSource.java
+++ b/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/TestWfsSource.java
@@ -280,7 +280,15 @@ public class TestWfsSource {
         return new WfsSource(mockWfs, new GeotoolsFilterAdapterImpl(), mockContext,
                 mockAvailabilityTask);
     }
-    
+
+    @Test
+    public void testAvailability() throws WfsException {
+        WfsSource source = getWfsSource(ONE_TEXT_PROPERTY_SCHEMA,
+                MockWfsServer.getFilterCapabilities(),
+                Wfs20Constants.EPSG_4326_URN, 1);
+        assertTrue(source.isAvailable());
+    }
+
     @Test
     public void testParseCapabilities() throws WfsException {
         WfsSource source = getWfsSource(ONE_TEXT_PROPERTY_SCHEMA,

--- a/wfs/spatial-wfs-mapper/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/mapper/impl/MetacardMapperImpl.java
+++ b/wfs/spatial-wfs-mapper/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/mapper/impl/MetacardMapperImpl.java
@@ -32,15 +32,15 @@ public class MetacardMapperImpl implements MetacardMapper {
     
     private String featureType;
     
-    BidiMap<String, String> bidiMap;
+    private BidiMap<String, String> bidiMap;
     
-    String dataUnit;
+    private String dataUnit;
     
-    String sortByTemporalFeatureProperty;
+    private String sortByTemporalFeatureProperty;
     
-    String sortByRelevanceFeatureProperty;
+    private String sortByRelevanceFeatureProperty;
     
-    String sortByDistanceFeatureProperty;
+    private String sortByDistanceFeatureProperty;
     
  
     public MetacardMapperImpl() {


### PR DESCRIPTION
When a Wfs source is configured, the initial availability check occurs after object creation/initialization. The catalog framework does not see the Wfs Source as available until the next run of the SourcePoller due to the CachedSource logic. 

Modify the Wfs 1.0 and 2.0 sources to check the availability at initialization so that the the correct availability is immediately available to the framework.

NOTE:  Because of threading, the two small tests are possibly not valid tests of the changes.
