### PR TITLE
DDF-1133: Removed resource URI conversion from CSW endpoint

### DIFF
--- a/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/reader/TestGetRecordsMessageBodyReader.java
+++ b/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/reader/TestGetRecordsMessageBodyReader.java
@@ -17,7 +17,6 @@ package org.codice.ddf.spatial.ogc.csw.catalog.source.reader;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.transform.InputTransformer;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswRecordCollection;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswRecordMetacardType;
@@ -67,7 +66,8 @@ public class TestGetRecordsMessageBodyReader {
     @Test
     public void testConfigurationArguments() throws Exception {
         when(mockInputManager.getTransformerBySchema(anyString()))
-                .thenReturn(new CswRecordConverter(null));
+.thenReturn(
+                new CswRecordConverter());
 
         CswSourceConfiguration config = new CswSourceConfiguration();
         config.setMetacardCswMappings(
@@ -115,8 +115,8 @@ public class TestGetRecordsMessageBodyReader {
     public void testFullThread() throws Exception {
         CswTransformProvider provider = new CswTransformProvider(null, mockInputManager);
 
-        when(mockInputManager.getTransformerBySchema(anyString()))
-                .thenReturn(new CswRecordConverter(null));
+        when(mockInputManager.getTransformerBySchema(anyString())).thenReturn(
+                new CswRecordConverter());
 
         CswSourceConfiguration config = new CswSourceConfiguration();
         Map<String, String> mappings = new HashMap<>();

--- a/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswRecordConverter.java
+++ b/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswRecordConverter.java
@@ -34,8 +34,7 @@ import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryCollection;
 import com.vividsolutions.jts.geom.GeometryFactory;
-import ddf.action.Action;
-import ddf.action.ActionProvider;
+
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType.AttributeFormat;
@@ -115,8 +114,6 @@ public class CswRecordConverter implements Converter, MetacardTransformer, Input
 
     protected NoNameCoder noNameCoder = new NoNameCoder();
 
-    private ActionProvider resourceActionProvider;
-
     /**
      * The map of metacard attributes that both the basic DDF MetacardTypeImpl and the CSW
      * MetacardType define as attributes. This is used to detect these element tags when
@@ -138,9 +135,7 @@ public class CswRecordConverter implements Converter, MetacardTransformer, Input
 
     private XStream xstream;
 
-    public CswRecordConverter(ActionProvider actionProvider) {
-        this.resourceActionProvider = actionProvider;
-
+    public CswRecordConverter() {
         xstream = new XStream(new Xpp3Driver());
         xstream.setClassLoader(this.getClass().getClassLoader());
         xstream.registerConverter(this);
@@ -177,22 +172,6 @@ public class CswRecordConverter implements Converter, MetacardTransformer, Input
         }
 
         MetacardImpl metacard = new MetacardImpl((Metacard) source);
-
-        if (metacard.getResourceURI() != null && resourceActionProvider != null) {
-            Action action = resourceActionProvider.getAction(metacard);
-            if (action != null) {
-                URL resourceUrl = action.getUrl();
-                if (resourceUrl != null) {
-                    try {
-                        metacard.setResourceURI(resourceUrl.toURI());
-                    } catch (URISyntaxException e) {
-                        LOGGER.warn("Unable to retrieve '{}' from '{}' for metacard ID [{}]",
-                                Metacard.RESOURCE_URI, resourceActionProvider.getClass().getName(),
-                                metacard.getId());
-                    }
-                }
-            }
-        }
 
         List<QName> fieldsToWrite = (List<QName>) arguments.get(CswConstants.ELEMENT_NAMES);
 

--- a/csw/spatial-csw-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/csw/spatial-csw-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,9 +24,7 @@
             <!-- TODO - still need to register OGCCORE for old school system -->
             <entry key="schema" value="http://www.opengis.net/cat/csw/2.0.2" />
 		</service-properties>
-		<bean class="org.codice.ddf.spatial.ogc.csw.catalog.converter.CswRecordConverter" >
-            <argument ref="resourceActionProvider" />
-        </bean>
+		<bean class="org.codice.ddf.spatial.ogc.csw.catalog.converter.CswRecordConverter" />
 	</service>
 
     <service interface="ddf.catalog.transform.MetacardTransformer">
@@ -35,9 +33,7 @@
             <entry key="mime-type" value="text/xml" />
             <entry key="schema" value="http://www.opengis.net/cat/csw/2.0.2" />
         </service-properties>
-        <bean class="org.codice.ddf.spatial.ogc.csw.catalog.converter.CswRecordConverter" >
-            <argument ref="resourceActionProvider" />
-        </bean>
+        <bean class="org.codice.ddf.spatial.ogc.csw.catalog.converter.CswRecordConverter" />
     </service>
 
     <service interface="ddf.catalog.transform.QueryResponseTransformer">

--- a/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestGetRecordsResponseConverter.java
+++ b/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestGetRecordsResponseConverter.java
@@ -136,8 +136,8 @@ public class TestGetRecordsResponseConverter {
 
         CswTransformProvider provider = new CswTransformProvider(null, mockInputManager);
 
-        when(mockInputManager.getTransformerBySchema(anyString()))
-                .thenReturn(new CswRecordConverter(null));
+        when(mockInputManager.getTransformerBySchema(anyString())).thenReturn(
+                new CswRecordConverter());
 
         xstream.registerConverter(new GetRecordsResponseConverter(provider));
         xstream.alias("GetRecordsResponse", CswRecordCollection.class);
@@ -685,7 +685,7 @@ public class TestGetRecordsResponseConverter {
 
         TransformerManager mockMetacardManager = mock(TransformerManager.class);
         when(mockMetacardManager.getTransformerBySchema(anyString())).thenReturn(
-                new CswRecordConverter(null));
+                new CswRecordConverter());
         GetRecordsResponseConverter rrConverter = new GetRecordsResponseConverter(new CswTransformProvider(mockMetacardManager, null));
 
         XStream xstream = new XStream(new StaxDriver(new NoNameCoder()));


### PR DESCRIPTION
Removed resource-uri conversion code from CswRecordConverter class as a new resource-download-url attribute is now added to all Metacards by the catalog framework. Also fixed a few warnings and
removed unused code.
