### PR TITLE
DDF-1298 Classloader/XML Parser issue in the container environment.

### DIFF
--- a/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
+++ b/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
@@ -1,16 +1,15 @@
 /**
  * Copyright (c) Codice Foundation
- *
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- *
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- *
  **/
 package org.codice.ddf.spatial.ogc.wfs.v2_0_0.catalog.source;
 
@@ -805,8 +804,8 @@ public class WfsSource extends MaskableImpl implements FederatedSource, Connecte
         }
     }
 
-    private JAXBElement<SortByType> buildSortBy(QName featureType, SortBy incomingSortBy) throws
-            UnsupportedQueryException {
+    private JAXBElement<SortByType> buildSortBy(QName featureType, SortBy incomingSortBy)
+            throws UnsupportedQueryException {
         net.opengis.filter.v_2_0_0.ObjectFactory filterObjectFactory = new net.opengis.filter.v_2_0_0.ObjectFactory();
 
         String propertyName = mapSortByPropertyName(featureType,
@@ -1000,8 +999,8 @@ public class WfsSource extends MaskableImpl implements FederatedSource, Connecte
     }
 
     @Override
-    public ResourceResponse retrieveResource(URI uri, Map<String, Serializable> arguments) throws
-            IOException, ResourceNotFoundException, ResourceNotSupportedException {
+    public ResourceResponse retrieveResource(URI uri, Map<String, Serializable> arguments)
+            throws IOException, ResourceNotFoundException, ResourceNotSupportedException {
         StringBuilder strBuilder = new StringBuilder();
         strBuilder.append("<html><script type=\"text/javascript\">window.location.replace(\"");
         strBuilder.append(uri);


### PR DESCRIPTION
Creating the unmarshaller instance without first setting the `contextClassLoader` was causing it to pull from the current bundle's classloader instead of the appropriate loader that has the `TransformerFactoryImpl` and the rest of the provider's implementation classes.

This change will need an integration test as it cannot be successfully demonstrated in the simpler loader ecosystem of unit tests; however, I'll need some guidance about what an appropriate integration test for this should look like.

Jason, I'm nominating you to be this PR's champion as you and Will have the most knowledge about the bug.
- @kcwire
- @millerw8
- @pklinef
- @wmcnalli
- @jlcsmith
- @beyelerb
- @emanns95
- @jrnorth

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-spatial/38)

<!-- Reviewable:end -->
