### PR TITLE
DDF-1325: Made the CSW Source query type configurable

### DIFF
--- a/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswSourceConfiguration.java
+++ b/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/CswSourceConfiguration.java
@@ -58,6 +58,10 @@ public class CswSourceConfiguration {
 
     private String outputSchema;
 
+    private String queryTypeQName;
+
+    private String queryTypePrefix;
+
     public String getCswUrl() {
         return cswUrl;
     }
@@ -213,5 +217,30 @@ public class CswSourceConfiguration {
 
     public void setOutputSchema(String outputSchema) {
         this.outputSchema = outputSchema;
+    }
+
+    public String getQueryTypeQName() {
+        return queryTypeQName;
+    }
+
+    public void setQueryTypeQName(String queryTypeQName) {
+        this.queryTypeQName = queryTypeQName;
+    }
+
+    public String getQueryTypePrefix() {
+        return queryTypePrefix;
+    }
+
+    public void setQueryTypePrefix(String queryTypePrefix) {
+        this.queryTypePrefix = queryTypePrefix;
+    }
+
+    public String getIdentifierMapping() {
+        return metacardCswMappings.get(Metacard.ID);
+    }
+
+    public void setIdentifierMapping(String identifierMapping) {
+        metacardCswMappings.put(Metacard.ID, identifierMapping);
+
     }
 }

--- a/csw/spatial-csw-source/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswFilterDelegate.java
+++ b/csw/spatial-csw-source/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswFilterDelegate.java
@@ -28,7 +28,6 @@ import javax.xml.namespace.QName;
 
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants.BinarySpatialOperand;
-import org.codice.ddf.spatial.ogc.csw.catalog.common.CswRecordMetacardType;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswSourceConfiguration;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -40,6 +39,7 @@ import com.vividsolutions.jts.io.WKTReader;
 import com.vividsolutions.jts.io.WKTWriter;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
 import net.opengis.filter.v_1_1_0.ComparisonOperatorType;
 import net.opengis.filter.v_1_1_0.ComparisonOperatorsType;
 import net.opengis.filter.v_1_1_0.FilterCapabilities;
@@ -81,7 +81,7 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
 
     private CswSourceConfiguration cswSourceConfiguration;
 
-    private CswRecordMetacardType cswRecordMetacardType;
+    private MetacardType metacardType;
 
     private CswFilterFactory cswFilterFactory;
 
@@ -97,11 +97,11 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
      * @param resultTypesValues
      *            An {@link net.opengis.ows.v_1_0_0.DomainType} containing a list of Result Types supported
      */
-    public CswFilterDelegate(CswRecordMetacardType cswRecordMetacardType, Operation getRecordsOp,
+    public CswFilterDelegate(MetacardType metacardType, Operation getRecordsOp,
             FilterCapabilities filterCapabilities, DomainType outputFormatValues,
             DomainType resultTypesValues, CswSourceConfiguration cswSourceConfiguration) {
         super(getRecordsOp, outputFormatValues, resultTypesValues);
-        this.cswRecordMetacardType = cswRecordMetacardType;
+        this.metacardType = metacardType;
         this.cswSourceConfiguration = cswSourceConfiguration;
         this.cswFilterFactory = new CswFilterFactory(cswSourceConfiguration.isLonLatOrder(),
                 cswSourceConfiguration.isSetUsePosList());
@@ -1124,7 +1124,7 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
         if (isAnyText(propertyName)) {
             propertyName = CswConstants.ANY_TEXT;
         } else if (isId(propertyName)) {
-            propertyName = CswRecordMetacardType.CSW_IDENTIFIER;
+            propertyName = cswSourceConfiguration.getIdentifierMapping();
         } else if (isAnyGeo(propertyName)) {
             propertyName = CswConstants.BBOX_PROP;
         } else if (isContentType(propertyName)) {
@@ -1359,8 +1359,8 @@ public class CswFilterDelegate extends CswAbstractFilterDelegate<FilterType> {
 
     private boolean isPropertyQueryable(String propertyName) {
         if (propertyName.equalsIgnoreCase(CswConstants.ANY_TEXT) || (
-                cswRecordMetacardType.getAttributeDescriptor(propertyName) != null
-                        && cswRecordMetacardType.getAttributeDescriptor(propertyName)
+                metacardType.getAttributeDescriptor(propertyName) != null
+                        && metacardType.getAttributeDescriptor(propertyName)
                         .isIndexed())) {
             LOGGER.debug("Property [{}] is queryable.", propertyName);
             return true;

--- a/csw/spatial-csw-source/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswSource.java
+++ b/csw/spatial-csw-source/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswSource.java
@@ -1277,20 +1277,20 @@ public class CswSource extends MaskableImpl implements FederatedSource, Connecte
      * Sets the {@link ddf.catalog.filter.FilterDelegate} used by the CswSource. May be overridden
      * in order to provide a custom ddf.catalog.filter.FilterDelegate implementation.
      *
-     * @param cswRecordMetacardType
+     * @param metacardType
      * @param getRecordsOp
      * @param filterCapabilities
      * @param outputFormatValues
      * @param resultTypesValues
      * @param cswSourceConfiguration
      */
-    protected void setFilterDelegate(CswRecordMetacardType cswRecordMetacardType,
+    protected void setFilterDelegate(MetacardType metacardType,
             Operation getRecordsOp, FilterCapabilities filterCapabilities,
             DomainType outputFormatValues, DomainType resultTypesValues,
             CswSourceConfiguration cswSourceConfiguration) {
         LOGGER.trace("Setting cswFilterDelegate to default CswFilterDelegate");
 
-        cswFilterDelegate = new CswFilterDelegate(cswRecordMetacardType, getRecordsOp,
+        cswFilterDelegate = new CswFilterDelegate(metacardType, getRecordsOp,
                 filterCapabilities, outputFormatValues, resultTypesValues, cswSourceConfiguration);
     }
 

--- a/csw/spatial-csw-source/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswSource.java
+++ b/csw/spatial-csw-source/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/source/CswSource.java
@@ -151,6 +151,8 @@ public class CswSource extends MaskableImpl implements FederatedSource, Connecte
 
     protected static final String CONTENT_TYPE_MAPPING_PROPERTY = "contentTypeMapping";
 
+    protected static final String IDENTIFIER_MAPPING_PROPERTY = "identifierMapping";
+
     protected static final String IS_LON_LAT_ORDER_PROPERTY = "isLonLatOrder";
 
     protected static final String POLL_INTERVAL_PROPERTY = "pollInterval";
@@ -164,6 +166,10 @@ public class CswSource extends MaskableImpl implements FederatedSource, Connecte
     protected static final String CONNECTION_TIMEOUT_PROPERTY = "connectionTimeout";
 
     protected static final String RECEIVE_TIMEOUT_PROPERTY = "receiveTimeout";
+
+    protected static final String QUERY_TYPE_QNAME_PROPERTY = "queryTypeQName";
+
+    protected static final String QUERY_TYPE_PREFIX_PROPERTY = "queryTypePrefix";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CswSource.class);
 
@@ -366,6 +372,21 @@ public class CswSource extends MaskableImpl implements FederatedSource, Connecte
                     oldOutputSchema);
         }
 
+        String queryTypeQName = (String) configuration.get(QUERY_TYPE_QNAME_PROPERTY);
+        if (StringUtils.isNotBlank(queryTypeQName)) {
+            cswSourceConfiguration.setQueryTypeQName(queryTypeQName);
+        }
+
+        String queryTypePrefix = (String) configuration.get(QUERY_TYPE_PREFIX_PROPERTY);
+        if (StringUtils.isNotBlank(queryTypePrefix)) {
+            cswSourceConfiguration.setQueryTypePrefix(queryTypePrefix);
+        }
+
+        String identifierMapping = (String) configuration.get(IDENTIFIER_MAPPING_PROPERTY);
+        if (StringUtils.isNotBlank(identifierMapping)) {
+            cswSourceConfiguration.setIdentifierMapping(identifierMapping);
+        }
+
         Boolean sslProp = (Boolean) configuration
                 .get(TrustedRemoteSource.DISABLE_CN_CHECK_PROPERTY);
         if (sslProp != null) {
@@ -546,6 +567,16 @@ public class CswSource extends MaskableImpl implements FederatedSource, Connecte
     public void setOutputSchema(String outputSchema) {
         cswSourceConfiguration.setOutputSchema(outputSchema);
         LOGGER.debug("Setting output schema to: {}", outputSchema);
+    }
+
+    public void setQueryTypeQName(String queryTypeQName) {
+        cswSourceConfiguration.setQueryTypeQName(queryTypeQName);
+        LOGGER.debug("Setting queryTypeQName to: {}", queryTypeQName);
+    }
+
+    public void setQueryTypePrefix(String queryTypePrefix) {
+        cswSourceConfiguration.setQueryTypePrefix(queryTypePrefix);
+        LOGGER.debug("Setting queryTypePrefix to: {}", queryTypePrefix);
     }
 
     @Override
@@ -806,6 +837,10 @@ public class CswSource extends MaskableImpl implements FederatedSource, Connecte
         cswSourceConfiguration.setThumbnailMapping(thumbnailMapping);
     }
 
+    public void setIdentifierMapping(String identifierMapping) {
+        cswSourceConfiguration.setIdentifierMapping(identifierMapping);
+    }
+
     public void setFilterAdapter(FilterAdapter filterAdapter) {
         this.filterAdapter = filterAdapter;
     }
@@ -870,9 +905,21 @@ public class CswSource extends MaskableImpl implements FederatedSource, Connecte
     private JAXBElement<QueryType> createQuery(Query query, ElementSetType elementSetType,
             List<QName> elementNames) throws UnsupportedQueryException {
         QueryType queryType = new QueryType();
-        queryType.setTypeNames(Arrays.asList(new QName[] {
-                new QName(CswConstants.CSW_OUTPUT_SCHEMA, CswConstants.CSW_RECORD_LOCAL_NAME,
-                        CswConstants.CSW_NAMESPACE_PREFIX)}));
+
+        QName queryTypeQName = null;
+        try {
+            queryTypeQName = new QName(
+                    QName.valueOf(cswSourceConfiguration.getQueryTypeQName()).getNamespaceURI(),
+                    QName.valueOf(cswSourceConfiguration.getQueryTypeQName()).getLocalPart(),
+                    cswSourceConfiguration.getQueryTypePrefix());
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Unable to parse query type QName of {}.  Defaulting to CSW Record",
+                    cswSourceConfiguration.getQueryTypeQName());
+            queryTypeQName = new QName(CswConstants.CSW_OUTPUT_SCHEMA,
+                    CswConstants.CSW_RECORD_LOCAL_NAME, CswConstants.CSW_NAMESPACE_PREFIX);
+        }
+
+        queryType.setTypeNames(Arrays.asList(new QName[] {queryTypeQName}));
         if (null != elementSetType) {
             queryType.setElementSetName(createElementSetName(elementSetType));
         } else if (!CollectionUtils.isEmpty(elementNames)) {

--- a/csw/spatial-csw-source/src/main/resources/META-INF/spring/beans.xml
+++ b/csw/spatial-csw-source/src/main/resources/META-INF/spring/beans.xml
@@ -70,12 +70,15 @@
             <beans:property name="modifiedDateMapping" value=""/>
             <beans:property name="resourceUriMapping" value=""/>
             <beans:property name="thumbnailMapping" value=""/>
+            <beans:property name="identifierMapping" value="identifier"/>
             <beans:property name="contentTypeNames">
                 <beans:list></beans:list>
             </beans:property>
             <beans:property name="pollInterval" value=""/>
             <beans:property name="resourceReaders" ref="resourceReaders"/>
             <beans:property name="outputSchema" value=""/>
+            <beans:property name="queryTypeQName" value=""/>
+            <beans:property name="queryTypePrefix" value=""/>
             <beans:property name="cswTransformProvider" ref="cswTransformProvider"/>
             <beans:property name="isCqlForced" value="false"/>
             <beans:property name="forceSpatialFilter" value=""/>
@@ -113,12 +116,15 @@
             <beans:property name="modifiedDateMapping" value=""/>
             <beans:property name="resourceUriMapping" value=""/>
             <beans:property name="thumbnailMapping" value=""/>
+            <beans:property name="identifierMapping" value="identifier"/>
             <beans:property name="contentTypeNames">
                 <beans:list></beans:list>
             </beans:property>
             <beans:property name="pollInterval" value=""/>
             <beans:property name="resourceReaders" ref="resourceReaders"/>
             <beans:property name="outputSchema" value=""/>
+            <beans:property name="queryTypeQName" value=""/>
+            <beans:property name="queryTypePrefix" value=""/>
             <beans:property name="cswTransformProvider" ref="cswTransformProvider"/>
             <beans:property name="isCqlForced" value="false"/>
             <beans:property name="forceSpatialFilter" value=""/>

--- a/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -26,15 +26,15 @@
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
             required="false" type="Password"/>
-            
+
         <AD description="Disable CN check for the server certificate. This should only be used when testing."
             name="Disable CN Check" id="disableCnCheck" required="true"
             type="Boolean" default="false"/>
-            
+
         <AD description="Force Longitude/Latitude coordinate order"
             name="Force Longitude/Latitude coordinate order" id="isLonLatOrder" required="true"
             type="Boolean" default="false"/>
-            
+
         <AD description="Use a <posList> element rather than a series of <pos> elements when issuing geospatial queries containing a LinearRing"
             name="Use posList in LinearRing" id="usePosList" required="false" type="Boolean"
             default="false"/>
@@ -51,12 +51,12 @@
             id="modifiedDateMapping"
             required="false" type="String"
             default="modified"/>
-            
+
         <AD description="CSW field to map to Metacard's resource URI to retrieve product associated with the CSW record."
             name="Resource URI maps to" id="resourceUriMapping"
             required="false" type="String"
             default="source"/>
-        	
+
         <AD description="CSW field to map to Metacard's thumbnail URI to retrieve thumbnail data associated with the CSW record."
             name="Thumbnail maps to" id="thumbnailMapping"
             required="false" type="String"
@@ -66,9 +66,14 @@
             id="contentTypeMapping" required="true"
             type="String" default="type"/>
 
+        <AD description="CSW field to map to Metacard's ID attribute."
+            name="ID maps to" id="identifierMapping"
+            required="true" type="String"
+            default="identifier"/>
+
         <AD name="Content Types" id="contentTypeNames" required="false" type="String"
             cardinality="100" description="The content types that can be found on server"/>
-        	
+
         <AD description="Poll Interval to Check if the Source is available (in minutes - minimum 1)."
             name="Poll Interval" id="pollInterval"
             required="true" type="Integer" default="5"/>
@@ -80,14 +85,22 @@
         <AD description="Amount of time to wait for a response before timing out, in milliseconds."
             name="Receive Timeout" id="receiveTimeout"
             required="true" type="Integer" default="60000"/>
-            
+
         <AD description="Output Schema" name="Output Schema" id="outputSchema" required="true"
             type="String" default="http://www.opengis.net/cat/csw/2.0.2"/>
-        
+
+        <AD description="Qualified Name for the Query Type used in the CSW GetRecords request"
+            name="Query Type QName" id="queryTypeQName" required="true" type="String"
+            default="{http://www.opengis.net/cat/csw/2.0.2}Record"/>
+
+        <AD description="Namespace prefix for the Query Type used in the CSW GetRecords request"
+            name="Query Type Namespace Prefix" id="queryTypePrefix" required="true" type="String"
+            default="csw"/>
+
         <AD description="Force CQL Text" name="Force CQL Text as the Query Language"
             id="isCqlForced" required="true"
             type="Boolean" default="false"/>
-            
+
         <AD description="Force only the selected Spatial Filter Type as the only available Spatial Filter."
             name="Forced Spatial Filter Type" id="forceSpatialFilter"
             required="false" type="String" default="NO_FILTER">
@@ -119,15 +132,15 @@
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
             required="false" type="String"/>
-            
+
         <AD description="Disable CN check for the server certificate. This should only be used when testing."
             name="Disable CN Check" id="disableCnCheck" required="true"
             type="Boolean" default="false"/>
-            
+
         <AD description="Force Longitude/Latitude coordinate order"
             name="Force Longitude/Latitude coordinate order" id="isLonLatOrder" required="true"
             type="Boolean" default="false"/>
-            
+
         <AD description="Use a <posList> element rather than a series of <pos> elements when issuing geospatial queries containing a LinearRing"
             name="Use posList in LinearRing" id="usePosList" required="false" type="Boolean"
             default="false"/>
@@ -144,12 +157,12 @@
             id="modifiedDateMapping"
             required="false" type="String"
             default="modified"/>
-            
+
         <AD description="CSW field to map to Metacard's resource URI to retrieve product associated with the CSW record."
             name="Resource URI maps to" id="resourceUriMapping"
             required="false" type="String"
             default="source"/>
-        	
+
         <AD description="CSW field to map to Metacard's thumbnail URI to retrieve thumbnail data associated with the CSW record."
             name="Thumbnail maps to" id="thumbnailMapping"
             required="false" type="String"
@@ -158,6 +171,11 @@
         <AD description="CSW field to map to Metacard's content type" name="Content type maps to"
             id="contentTypeMapping" required="true"
             type="String" default="type"/>
+
+        <AD description="CSW field to map to Metacard's ID attribute."
+            name="ID maps to" id="identifierMapping"
+            required="true" type="String"
+            default="identifier"/>
 
         <AD name="Content Types" id="contentTypeNames" required="false" type="String"
             cardinality="100" description="The content types that can be found on server"/>
@@ -176,11 +194,19 @@
 
         <AD description="Output Schema" name="Output Schema" id="outputSchema" required="true"
             type="String" default="http://www.opengis.net/cat/csw/2.0.2"/>
-        
+
+        <AD description="Qualified Name for the Query Type used in the CSW GetRecords request"
+            name="Query Type QName" id="queryTypeQName" required="true" type="String"
+            default="{http://www.opengis.net/cat/csw/2.0.2}Record"/>
+
+        <AD description="Namespace prefix for the Query Type used in the CSW GetRecords request"
+            name="Query Type Namespace Prefix" id="queryTypePrefix" required="true" type="String"
+            default="csw"/>
+
         <AD description="Force CQL Text" name="Force CQL Text as the Query Language"
             id="isCqlForced" required="true"
             type="Boolean" default="false"/>
-            
+
         <AD description="Force only the selected Spatial Filter Type as the only available Spatial Filter."
             name="Forced Spatial Filter Type" id="forceSpatialFilter"
             required="false" type="String" default="">

--- a/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/TestCswCqlFilter.java
+++ b/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/TestCswCqlFilter.java
@@ -527,6 +527,26 @@ public class TestCswCqlFilter {
     }
 
     /**
+     * Property is equal to with alternate id property
+     *
+     * @throws UnsupportedQueryException
+     */
+    @Test
+    public void testPropertyIsEqualToStringLiteralAlternateIdMapping()
+            throws UnsupportedQueryException {
+        String replacedIdentifierProperty = propertyName;
+        CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false,
+                CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, createdDateMapping,
+                modifiedDateMapping, replacedIdentifierProperty);
+
+        CswFilterDelegate cswFilterDelegate = initDefaultCswFilterDelegate(cswSourceConfiguration);
+        FilterType filterType = cswFilterDelegate
+                .propertyIsEqualTo(propertyName, stringLiteral, isCaseSensitive);
+        String cqlText = CswCqlTextFilter.getInstance().getCqlText(filterType);
+        assertEquals(propertyIsEqualTo, cqlText);
+    }
+
+    /**
      * Verify that when given a non ISO 8601 formatted date, the CswFilterDelegate converts the date
      * to ISO 8601 format (ie. the xml generated off of the filterType should have an ISO 8601
      * formatted date in it).
@@ -555,7 +575,7 @@ public class TestCswCqlFilter {
         DateTime endDate = new DateTime(2013, 12, 31, 0, 0, 0, 0);
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false,
                 CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, createdDateMapping,
-                modifiedDateMapping);
+                modifiedDateMapping, CswRecordMetacardType.CSW_IDENTIFIER);
 
         CswFilterDelegate cswFilterDelegate = initDefaultCswFilterDelegate(cswSourceConfiguration);
         FilterType filterType = cswFilterDelegate
@@ -583,7 +603,7 @@ public class TestCswCqlFilter {
         String replacedTemporalProperty = "myEffectiveDate";
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false,
                 CswRecordMetacardType.CSW_TYPE, replacedTemporalProperty, createdDateMapping,
-                modifiedDateMapping);
+                modifiedDateMapping, CswRecordMetacardType.CSW_IDENTIFIER);
 
         CswFilterDelegate cswFilterDelegate = initDefaultCswFilterDelegate(cswSourceConfiguration);
         FilterType filterType = cswFilterDelegate
@@ -608,7 +628,7 @@ public class TestCswCqlFilter {
         String replacedTemporalProperty = "myCreatedDate";
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false,
                 CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, replacedTemporalProperty,
-                modifiedDateMapping);
+                modifiedDateMapping, CswRecordMetacardType.CSW_IDENTIFIER);
 
         CswFilterDelegate localCswFilterDelegate = initDefaultCswFilterDelegate(
                 cswSourceConfiguration);
@@ -635,7 +655,7 @@ public class TestCswCqlFilter {
         String replacedTemporalProperty = "myModifiedDate";
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false,
                 CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, createdDateMapping,
-                replacedTemporalProperty);
+                replacedTemporalProperty, CswRecordMetacardType.CSW_IDENTIFIER);
 
         CswFilterDelegate localCswFilterDelegate = initDefaultCswFilterDelegate(
                 cswSourceConfiguration);
@@ -659,7 +679,7 @@ public class TestCswCqlFilter {
         long duration = 92000000000L;
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false,
                 CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, createdDateMapping,
-                modifiedDateMapping);
+                modifiedDateMapping, CswRecordMetacardType.CSW_IDENTIFIER);
         CswFilterDelegate localCswFilterDelegate = initDefaultCswFilterDelegate(
                 cswSourceConfiguration);
         FilterType filterType = localCswFilterDelegate.relative(propertyNameModified, duration);
@@ -1394,6 +1414,7 @@ public class TestCswCqlFilter {
     private CswSourceConfiguration initCswSourceConfiguration(boolean isLonLatOrder,
             String contentType) {
         CswSourceConfiguration cswSourceConfiguration = new CswSourceConfiguration();
+        cswSourceConfiguration.setIdentifierMapping(CswRecordMetacardType.CSW_IDENTIFIER);
         cswSourceConfiguration.setIsLonLatOrder(isLonLatOrder);
         cswSourceConfiguration.setContentTypeMapping(contentType);
         return cswSourceConfiguration;
@@ -1401,8 +1422,9 @@ public class TestCswCqlFilter {
 
     private CswSourceConfiguration initCswSourceConfiguration(boolean isLonLatOrder,
             String contentType, String effectiveDateMapping, String createdDateMapping,
-            String modifiedDateMapping) {
+            String modifiedDateMapping, String identifierMapping) {
         CswSourceConfiguration cswSourceConfiguration = new CswSourceConfiguration();
+        cswSourceConfiguration.setIdentifierMapping(identifierMapping);
         cswSourceConfiguration.setIsLonLatOrder(isLonLatOrder);
         cswSourceConfiguration.setContentTypeMapping(contentType);
         cswSourceConfiguration.setEffectiveDateMapping(effectiveDateMapping);

--- a/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/TestCswFilterDelegate.java
+++ b/csw/spatial-csw-source/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/source/TestCswFilterDelegate.java
@@ -1186,7 +1186,7 @@ public class TestCswFilterDelegate {
     public void testDuring() throws JAXBException, SAXException, IOException {
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false, false,
                 CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, createdDateMapping,
-                modifiedDateMapping);
+                modifiedDateMapping, CswRecordMetacardType.CSW_IDENTIFIER);
 
         CswFilterDelegate localCswFilterDelegate = createCswFilterDelegate(cswSourceConfiguration);
 
@@ -1208,7 +1208,7 @@ public class TestCswFilterDelegate {
         // Setup
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false, false,
                 CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, createdDateMapping,
-                modifiedDateMapping);
+                modifiedDateMapping, CswRecordMetacardType.CSW_IDENTIFIER);
 
         DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
         String dateStr = fmt.print(testStartDate);
@@ -1230,7 +1230,7 @@ public class TestCswFilterDelegate {
         // Setup
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false, false,
                 CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, createdDateMapping,
-                modifiedDateMapping);
+                modifiedDateMapping, CswRecordMetacardType.CSW_IDENTIFIER);
 
         DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
         String dateStr = fmt.print(testStartDate);
@@ -1254,7 +1254,7 @@ public class TestCswFilterDelegate {
         String replacedTemporalProperty = "myEffectiveDate";
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false, false,
                 CswRecordMetacardType.CSW_TYPE, replacedTemporalProperty, createdDateMapping,
-                modifiedDateMapping);
+                modifiedDateMapping, CswRecordMetacardType.CSW_IDENTIFIER);
 
         CswFilterDelegate localCswFilterDelegate = createCswFilterDelegate(cswSourceConfiguration);
 
@@ -1277,7 +1277,7 @@ public class TestCswFilterDelegate {
         String replacedTemporalProperty = "myCreatedDate";
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false, false,
                 CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, replacedTemporalProperty,
-                modifiedDateMapping);
+                modifiedDateMapping, CswRecordMetacardType.CSW_IDENTIFIER);
 
         CswFilterDelegate localCswFilterDelegate = createCswFilterDelegate(cswSourceConfiguration);
 
@@ -1301,7 +1301,7 @@ public class TestCswFilterDelegate {
         String replacedTemporalProperty = "myModifiedDate";
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false, false,
                 CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, createdDateMapping,
-                replacedTemporalProperty);
+                replacedTemporalProperty, CswRecordMetacardType.CSW_IDENTIFIER);
 
         CswFilterDelegate localCswFilterDelegate = createCswFilterDelegate(cswSourceConfiguration);
 
@@ -1318,12 +1318,28 @@ public class TestCswFilterDelegate {
     }
 
     @Test
+    public void testPropertyIsEqualToAlternateIdMapping()
+            throws JAXBException, SAXException, IOException {
+
+        String replacedIdentifierProperty = propertyName;
+        CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false, false,
+                CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, createdDateMapping,
+                modifiedDateMapping, replacedIdentifierProperty);
+
+        CswFilterDelegate localCswFilterDelegate = createCswFilterDelegate(cswSourceConfiguration);
+
+        FilterType filterType = localCswFilterDelegate
+                .propertyIsEqualTo(Metacard.ID, stringLiteral, isCaseSensitive);
+        assertXMLEqual(propertyIsEqualToXml, getXmlFromMarshaller(filterType));
+    }
+
+    @Test
     public void testRelative() throws JAXBException, SAXException, IOException {
         long duration = 92000000000L;
 
         CswSourceConfiguration cswSourceConfiguration = initCswSourceConfiguration(false, false,
                 CswRecordMetacardType.CSW_TYPE, effectiveDateMapping, createdDateMapping,
-                modifiedDateMapping);
+                modifiedDateMapping, CswRecordMetacardType.CSW_IDENTIFIER);
         CswFilterDelegate localCswFilterDelegate = createCswFilterDelegate(cswSourceConfiguration);
 
         Map<String, Object> propMap = new HashMap<String, Object>();
@@ -2769,6 +2785,7 @@ public class TestCswFilterDelegate {
     private CswSourceConfiguration initCswSourceConfiguration(boolean isLonLatOrder,
             boolean usePosList, String contentType) {
         CswSourceConfiguration cswSourceConfiguration = new CswSourceConfiguration();
+        cswSourceConfiguration.setIdentifierMapping(CswRecordMetacardType.CSW_IDENTIFIER);
         cswSourceConfiguration.setIsLonLatOrder(isLonLatOrder);
         cswSourceConfiguration.setUsePosList(usePosList);
         cswSourceConfiguration.setContentTypeMapping(contentType);
@@ -2777,8 +2794,9 @@ public class TestCswFilterDelegate {
 
     private CswSourceConfiguration initCswSourceConfiguration(boolean isLonLatOrder,
             boolean usePosList, String contentType, String effectiveDateMapping,
-            String createdDateMapping, String modifiedDateMapping) {
+            String createdDateMapping, String modifiedDateMapping, String identifierMapping) {
         CswSourceConfiguration cswSourceConfiguration = new CswSourceConfiguration();
+        cswSourceConfiguration.setIdentifierMapping(identifierMapping);
         cswSourceConfiguration.setIsLonLatOrder(isLonLatOrder);
         cswSourceConfiguration.setUsePosList(usePosList);
         cswSourceConfiguration.setContentTypeMapping(contentType);


### PR DESCRIPTION
- query type qname and prefix is configurable
- removed dependency on CSW Record MetacardType
- added query mapping for id attribute

@millerw8 @kcwire @wmcnalli @beyelerb @emanns95 @coyotesqrl

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-spatial/40)

<!-- Reviewable:end -->
